### PR TITLE
display Experiment URL to stdout automatically through Experiment object instead of specifying it manually within script

### DIFF
--- a/examples/src/main/java/dev/braintrust/examples/SimpleExperimentWithRegistration.java
+++ b/examples/src/main/java/dev/braintrust/examples/SimpleExperimentWithRegistration.java
@@ -38,28 +38,6 @@ public class SimpleExperimentWithRegistration {
         var experiment = Experiment.registerExperimentSync(experimentName, project.id());
         System.out.println("Experiment ID: " + experiment.id());
 
-        // Get the app URL from config
-        var appUrl = config.appUrl().toString().replaceAll("/$", "");
-        // URLEncoder.encode uses + for spaces, but we need %20 for URL paths
-        var projectNameEncoded =
-                java.net.URLEncoder.encode(project.name(), java.nio.charset.StandardCharsets.UTF_8)
-                        .replace("+", "%20");
-
-        // For staging, we need to handle the org differently
-        var baseExperimentUrl =
-                appUrl.contains("staging")
-                        ? String.format(
-                                "%s/app/%s/p/%s/experiments/%s",
-                                appUrl, project.orgId(), projectNameEncoded, experimentName)
-                        : String.format(
-                                "%s/app/braintrustdata.com/p/%s/experiments/%s",
-                                appUrl, projectNameEncoded, experimentName);
-
-        // TODO: Add comparison parameter if there's a previous experiment
-        var experimentUrl = baseExperimentUrl;
-
-        System.out.println("\nExperiment " + experimentName + " is running at " + experimentUrl);
-
         // Step 3: Set up tracing context with experiment (similar to Go's trace.SetParent)
         var braintrustContext = BraintrustContext.forExperiment(experiment.id());
         var context = braintrustContext.storeInContext(Context.current()).makeCurrent();
@@ -138,7 +116,7 @@ public class SimpleExperimentWithRegistration {
         }
 
         System.out.println("\n=== View in Braintrust ===");
-        System.out.println("See results for " + experimentName + " at " + experimentUrl);
+        System.out.println("See results for " + experimentName + " in the Braintrust web app.");
 
         // Clean up context
         context.close();

--- a/examples/src/main/java/dev/braintrust/examples/TriviaEvaluation.java
+++ b/examples/src/main/java/dev/braintrust/examples/TriviaEvaluation.java
@@ -59,23 +59,6 @@ public class TriviaEvaluation {
         var experiment = Experiment.registerExperimentSync(experimentName, project.id());
         System.out.println("Experiment ID: " + experiment.id());
 
-        // Show experiment URL
-        var appUrl = config.appUrl().toString().replaceAll("/$", "");
-        var orgNameEncoded =
-                java.net.URLEncoder.encode(
-                                config.orgName().orElse("unknown"),
-                                java.nio.charset.StandardCharsets.UTF_8)
-                        .replace("+", "%20");
-        var projectNameEncoded =
-                java.net.URLEncoder.encode(project.name(), java.nio.charset.StandardCharsets.UTF_8)
-                        .replace("+", "%20");
-        var experimentUrl =
-                String.format(
-                        "%s/app/%s/p/%s/experiments/%s",
-                        appUrl, orgNameEncoded, projectNameEncoded, experimentName);
-
-        System.out.println("\nExperiment " + experimentName + " is running at " + experimentUrl);
-
         // Step 3: Set up tracing context
         var braintrustContext = BraintrustContext.forExperiment(experiment.id());
         var context = braintrustContext.storeInContext(Context.current()).makeCurrent();
@@ -181,7 +164,7 @@ public class TriviaEvaluation {
         }
 
         System.out.println("\n=== View in Braintrust ===");
-        System.out.println("See results for " + experimentName + " at " + experimentUrl);
+        System.out.println("See results for " + experimentName + " in the Braintrust web app.");
 
         // Clean up
         context.close();

--- a/src/test/java/dev/braintrust/api/ExperimentTest.java
+++ b/src/test/java/dev/braintrust/api/ExperimentTest.java
@@ -1,0 +1,116 @@
+package dev.braintrust.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.braintrust.config.BraintrustConfig;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ExperimentTest {
+
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+
+    @BeforeEach
+    void setUp() {
+        System.setOut(new PrintStream(outputStream));
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void testDisplayExperimentUrl() throws Exception {
+        // Create test data
+        var experiment =
+                new BraintrustApiClient.Experiment(
+                        "exp-123",
+                        "proj-456",
+                        "test-experiment",
+                        Optional.of("Test description"),
+                        "2024-01-01T00:00:00Z",
+                        "2024-01-01T00:00:00Z");
+        var project =
+                new BraintrustApiClient.Project(
+                        "proj-456",
+                        "Test Project",
+                        "org-789",
+                        "2024-01-01T00:00:00Z",
+                        "2024-01-01T00:00:00Z");
+        var config =
+                BraintrustConfig.builder()
+                        .apiKey("test-key")
+                        .apiUrl("https://api.braintrust.dev")
+                        .appUrl(URI.create("https://www.braintrust.dev"))
+                        .orgName("Test Org")
+                        .build();
+
+        // Use reflection to call the private method
+        var method =
+                Experiment.class.getDeclaredMethod(
+                        "displayExperimentUrl",
+                        BraintrustApiClient.Experiment.class,
+                        BraintrustApiClient.Project.class,
+                        BraintrustConfig.class);
+        method.setAccessible(true);
+        method.invoke(null, experiment, project, config);
+
+        // Verify the output
+        var output = outputStream.toString();
+        assertThat(output).contains("Experiment test-experiment is running at");
+        assertThat(output)
+                .contains(
+                        "https://www.braintrust.dev/app/Test%20Org/p/Test%20Project/experiments/test-experiment");
+    }
+
+    @Test
+    void testDisplayExperimentUrlWithSpaces() throws Exception {
+        // Test with spaces in org and project names
+        var experiment =
+                new BraintrustApiClient.Experiment(
+                        "exp-123",
+                        "proj-456",
+                        "test experiment",
+                        Optional.of("Test description"),
+                        "2024-01-01T00:00:00Z",
+                        "2024-01-01T00:00:00Z");
+        var project =
+                new BraintrustApiClient.Project(
+                        "proj-456",
+                        "Test Project With Spaces",
+                        "org-789",
+                        "2024-01-01T00:00:00Z",
+                        "2024-01-01T00:00:00Z");
+        var config =
+                BraintrustConfig.builder()
+                        .apiKey("test-key")
+                        .apiUrl("https://api.braintrust.dev")
+                        .appUrl(URI.create("https://www.braintrust.dev"))
+                        .orgName("Test Org With Spaces")
+                        .build();
+
+        // Use reflection to call the private method
+        var method =
+                Experiment.class.getDeclaredMethod(
+                        "displayExperimentUrl",
+                        BraintrustApiClient.Experiment.class,
+                        BraintrustApiClient.Project.class,
+                        BraintrustConfig.class);
+        method.setAccessible(true);
+        method.invoke(null, experiment, project, config);
+
+        // Verify the output with proper URL encoding
+        var output = outputStream.toString();
+        assertThat(output).contains("Experiment test experiment is running at");
+        assertThat(output)
+                .contains(
+                        "https://www.braintrust.dev/app/Test%20Org%20With%20Spaces/p/Test%20Project%20With%20Spaces/experiments/test%20experiment");
+    }
+}


### PR DESCRIPTION
I'm trying to get similar DX to the py/TS SDKs where the URL is sent to stdout automatically when Eval is initiated
<img width="1932" height="64" alt="CleanShot 2025-07-13 at 11 50 39@2x" src="https://github.com/user-attachments/assets/b67ce5f3-7962-484b-8fbe-20544a834ad9" />


Next steps after this:
- Conform around datasets being input/expected/metadata. Right now Evaluation.java is looking for "question" instead of input. 
- Fix trivia example to declare expected instead of expectedAnswer in dataset
- Abstract Eval summary and reporting into Experiments or Evaluations object instead of example scripts