### PR TITLE
Update testParallelEvaluation to not depend on overhead

### DIFF
--- a/src/test/java/dev/braintrust/eval/EvaluationTest.java
+++ b/src/test/java/dev/braintrust/eval/EvaluationTest.java
@@ -114,7 +114,7 @@ class EvaluationTest {
                 results.results().stream().mapToLong(r -> r.duration().toMillis()).sum();
 
         // Total work time should be > 1000ms but wall time should be much less
-        assertThat(totalDuration).isGreaterThan(1000);
+        assertThat(totalDuration).isGreaterThanOrEqualTo(1000);
     }
 
     @Test


### PR DESCRIPTION
In the test we don't always accumulate 1ms of overhead so the check should be GreaterThanOrEqualTo. 