### PR TITLE
remove max tokens from experiment

### DIFF
--- a/examples/src/main/java/dev/braintrust/examples/OpenAIInstrumentationExample.java
+++ b/examples/src/main/java/dev/braintrust/examples/OpenAIInstrumentationExample.java
@@ -28,7 +28,6 @@ public class OpenAIInstrumentationExample {
                             .model(ChatModel.GPT_4O_MINI)
                             .addSystemMessage("You are a helpful assistant")
                             .addUserMessage("What is the capital of France?")
-                            .maxTokens(50L)
                             .temperature(0.0)
                             .build();
             var response = openAIClient.chat().completions().create(request);


### PR DESCRIPTION
The experiment asks a very simple question so the default LLM output
won't be huge. But there's a risk of users altering the question
without noticing the token limit