### PR TITLE
send input_json and output_json instead

### DIFF
--- a/src/main/java/dev/braintrust/instrumentation/openai/otel/ChatCompletionEventsHelper.java
+++ b/src/main/java/dev/braintrust/instrumentation/openai/otel/ChatCompletionEventsHelper.java
@@ -73,7 +73,7 @@ final class ChatCompletionEventsHelper {
                     try {
                         Span.current()
                                 .setAttribute(
-                                        "braintrust.input",
+                                        "braintrust.input_json",
                                         JSON_MAPPER.writeValueAsString(content));
                     } catch (JsonProcessingException e) {
                         BraintrustLogger.error("Error mapping json", e);
@@ -198,7 +198,7 @@ final class ChatCompletionEventsHelper {
             boolean captureMessageContent) {
         try {
             var completionJson = JSON_MAPPER.writeValueAsString(completion);
-            Span.current().setAttribute("braintrust.output", completionJson);
+            Span.current().setAttribute("braintrust.output_json", completionJson);
         } catch (JsonProcessingException e) {
             BraintrustLogger.error("Error mapping completion json", e);
         }


### PR DESCRIPTION
The `_json` attributes are auto-unwrapped by the backend